### PR TITLE
Issue 181: fix addind team members via context menu

### DIFF
--- a/frontend/src/components/app/ContextMenuConfigs.tsx
+++ b/frontend/src/components/app/ContextMenuConfigs.tsx
@@ -197,8 +197,13 @@ const TeamContextMenuItems = ({rows}: { rows: Row<{ _id: string }>[] }) => {
 
     const setSelectedRoomsData = useSetAtom($selectedTeamsData)
     const data = rows.map(it => ({
-        _id: it.getValue('_id') as string
+        _id: it.getValue('_id') as string,
+        roomId: (it.original as any)?.roomId || 
+                it.getValue('roomId') || 
+                undefined
     }))
+    
+    console.log('Constructed data:', data);
 
     return (
         <>


### PR DESCRIPTION
**Что было сделано:**
В TeamContextMenuItems извлекается roomId из полных данных строки. Оно передаётся в $selectedTeamsData
**Зачем это было сделано:**
Чтобы обеспечить добавление пользователей в команды через контекстное меню на странице с командами.
Без этих данных возвращается ошибка 422
**Как это было протестировано:**
Ручное тестирование