### PR TITLE
Issue 184: Email templates on frontend

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field, HttpUrl, EmailStr, AnyUrl
-from typing import Optional, List
+from typing import Optional, List, Literal, Dict
 from app.services.db import DbModel
 from datetime import datetime
 
@@ -218,6 +218,65 @@ class SmtpSettingsModel(DbModel):
 
 class SmtpSettingsResponseDto(BaseModel):
     value: Optional[SmtpSettingsDto]
+
+
+EmailTemplateKey = Literal["welcome_user", "password_changed"]
+
+
+class EmailTemplateDto(BaseModel):
+    key: EmailTemplateKey
+    subject: str
+    body: str
+
+
+class EmailTemplatesMapDto(BaseModel):
+    welcome_user: EmailTemplateDto
+    password_changed: EmailTemplateDto
+
+
+class EmailTemplateUpsertDto(BaseModel):
+    subject: str = Field(min_length=1)
+    body: str = Field(min_length=1)
+
+
+class EmailTemplatePreviewRequestDto(BaseModel):
+    template: EmailTemplateUpsertDto
+    context: Optional[Dict[str, str]] = None
+
+
+class EmailTemplatePreviewResponseDto(BaseModel):
+    subject: str
+    body: str
+
+
+class EmailTemplateTestSendRequestDto(BaseModel):
+    template: EmailTemplateUpsertDto
+    context: Optional[Dict[str, str]] = None
+    to: EmailStr
+
+
+class EmailTemplateTestSendResponseDto(BaseModel):
+    recipient: EmailStr
+    message_id: str
+
+
+class EmailTemplateMetaDto(BaseModel):
+    key: EmailTemplateKey
+    description: str
+    available_variables: List[str]
+    required_variables: List[str]
+
+
+class EmailTemplatesMetaResponseDto(BaseModel):
+    items: List[EmailTemplateMetaDto]
+
+
+class EmailTemplateModel(DbModel):
+    space_id: str
+    key: EmailTemplateKey
+    subject: str
+    body: str
+    updated_at: datetime
 
 
 class UsersToChangePasswordDto(BaseModel):

--- a/frontend/src/api/email-templates-stub.ts
+++ b/frontend/src/api/email-templates-stub.ts
@@ -1,0 +1,215 @@
+export type EmailTemplateKey = "welcome_user" | "password_changed";
+
+export type EmailTemplateModel = {
+    subject: string;
+    body: string;
+};
+
+export type EmailTemplateCollection = Record<EmailTemplateKey, EmailTemplateModel>;
+
+export type EmailTemplateConfig = {
+    key: EmailTemplateKey;
+    label: string;
+    description: string;
+    availableVariables: string[];
+    requiredVariables: string[];
+    sampleContext: Record<string, string>;
+};
+
+type StoredTemplates = Partial<Record<EmailTemplateKey, Partial<EmailTemplateModel>>>;
+
+const STORAGE_KEY_PREFIX = "rocket_email_templates_v1";
+
+const TOKEN_PATTERN = /{{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*}}/g;
+
+const wait = (ms: number) =>
+    new Promise<void>((resolve) => {
+        setTimeout(resolve, ms);
+    });
+
+export const EMAIL_TEMPLATE_CONFIGS: Record<EmailTemplateKey, EmailTemplateConfig> = {
+    welcome_user: {
+        key: "welcome_user",
+        label: "welcome_user",
+        description: "Письмо отправляется пользователю после создания аккаунта.",
+        availableVariables: ["username", "space_url", "password"],
+        requiredVariables: ["space_url", "password"],
+        sampleContext: {
+            username: "new_user",
+            space_url: "https://example.space",
+            password: "TempPass123",
+        },
+    },
+    password_changed: {
+        key: "password_changed",
+        label: "password_changed",
+        description: "Письмо отправляется пользователю после смены пароля.",
+        availableVariables: ["username", "space_url", "password"],
+        requiredVariables: ["space_url", "password"],
+        sampleContext: {
+            username: "existing_user",
+            space_url: "https://example.space",
+            password: "NewPass456",
+        },
+    },
+};
+
+export const DEFAULT_EMAIL_TEMPLATES: EmailTemplateCollection = {
+    welcome_user: {
+        subject: "Ваш аккаунт в {{space_url}} создан",
+        body: "Добро пожаловать, {{username}}!\n\nВаш временный пароль: {{password}}\n\nПространство: {{space_url}}",
+    },
+    password_changed: {
+        subject: "Пароль изменен в {{space_url}}",
+        body: "Здравствуйте, {{username}}.\n\nВаш новый пароль: {{password}}\n\nПространство: {{space_url}}",
+    },
+};
+
+function getStorageKey(spaceId: string): string {
+    return `${STORAGE_KEY_PREFIX}:${spaceId}`;
+}
+
+function readStoredTemplates(spaceId: string): StoredTemplates {
+    if (!spaceId || typeof window === "undefined") {
+        return {};
+    }
+
+    const raw = window.localStorage.getItem(getStorageKey(spaceId));
+    if (!raw) {
+        return {};
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(raw);
+        if (!parsed || typeof parsed !== "object") {
+            return {};
+        }
+        return parsed as StoredTemplates;
+    } catch {
+        return {};
+    }
+}
+
+function writeStoredTemplates(spaceId: string, templates: StoredTemplates): void {
+    if (!spaceId || typeof window === "undefined") {
+        return;
+    }
+    window.localStorage.setItem(getStorageKey(spaceId), JSON.stringify(templates));
+}
+
+function normalizeTemplate(
+    value: Partial<EmailTemplateModel> | undefined,
+    fallback: EmailTemplateModel,
+): EmailTemplateModel {
+    return {
+        subject: value?.subject ?? fallback.subject,
+        body: value?.body ?? fallback.body,
+    };
+}
+
+function renderTemplateString(template: string, context: Record<string, string>): string {
+    return template.replace(TOKEN_PATTERN, (_, variableName: string) => {
+        if (Object.prototype.hasOwnProperty.call(context, variableName)) {
+            return context[variableName];
+        }
+        return `{{${variableName}}}`;
+    });
+}
+
+export function extractTemplateVariables(content: string): string[] {
+    const regex = new RegExp(TOKEN_PATTERN.source, "g");
+    const variables = new Set<string>();
+    const matches = content.matchAll(regex);
+
+    for (const match of matches) {
+        const variableName = match[1];
+        if (variableName) {
+            variables.add(variableName);
+        }
+    }
+
+    return [...variables];
+}
+
+export function findMissingRequiredVariables(params: {
+    subject: string;
+    body: string;
+    requiredVariables: string[];
+}): string[] {
+    const usedVariables = new Set(
+        extractTemplateVariables(`${params.subject}\n${params.body}`),
+    );
+
+    return params.requiredVariables.filter((variableName) => !usedVariables.has(variableName));
+}
+
+export function findUnknownVariables(params: {
+    subject: string;
+    body: string;
+    availableVariables: string[];
+}): string[] {
+    const usedVariables = extractTemplateVariables(`${params.subject}\n${params.body}`);
+    const availableVariables = new Set(params.availableVariables);
+
+    return usedVariables.filter((variableName) => !availableVariables.has(variableName));
+}
+
+export async function fetchEmailTemplates(spaceId: string): Promise<EmailTemplateCollection> {
+    await wait(200);
+
+    const stored = readStoredTemplates(spaceId);
+    return {
+        welcome_user: normalizeTemplate(stored.welcome_user, DEFAULT_EMAIL_TEMPLATES.welcome_user),
+        password_changed: normalizeTemplate(stored.password_changed, DEFAULT_EMAIL_TEMPLATES.password_changed),
+    };
+}
+
+export async function saveEmailTemplate(params: {
+    spaceId: string;
+    key: EmailTemplateKey;
+    template: EmailTemplateModel;
+}): Promise<EmailTemplateModel> {
+    await wait(250);
+
+    const stored = readStoredTemplates(params.spaceId);
+    stored[params.key] = {
+        subject: params.template.subject,
+        body: params.template.body,
+    };
+    writeStoredTemplates(params.spaceId, stored);
+
+    return params.template;
+}
+
+export async function previewEmailTemplate(params: {
+    key: EmailTemplateKey;
+    template: EmailTemplateModel;
+    context?: Record<string, string>;
+}): Promise<EmailTemplateModel> {
+    await wait(200);
+
+    const config = EMAIL_TEMPLATE_CONFIGS[params.key];
+    const context = {
+        ...config.sampleContext,
+        ...(params.context ?? {}),
+    };
+
+    return {
+        subject: renderTemplateString(params.template.subject, context),
+        body: renderTemplateString(params.template.body, context),
+    };
+}
+
+export async function testSendEmailTemplate(params: {
+    key: EmailTemplateKey;
+    template: EmailTemplateModel;
+    context?: Record<string, string>;
+}): Promise<{ recipient: string; messageId: string }> {
+    await previewEmailTemplate(params);
+    await wait(200);
+
+    return {
+        recipient: "test@example.com",
+        messageId: `stub-${Date.now()}`,
+    };
+}

--- a/frontend/src/routes/spaces/dashboard/settings/EmailTemplatesSettings.tsx
+++ b/frontend/src/routes/spaces/dashboard/settings/EmailTemplatesSettings.tsx
@@ -1,0 +1,442 @@
+import {useEffect, useMemo, useRef, useState} from "react";
+import {useForm} from "react-hook-form";
+import {z} from "zod";
+import {zodResolver} from "@hookform/resolvers/zod";
+import {toast} from "sonner";
+import {Loader2} from "lucide-react";
+
+import {Card, CardContent, CardHeader} from "@/components/ui/card.tsx";
+import {Button} from "@/components/ui/button.tsx";
+import {Input} from "@/components/ui/input.tsx";
+import {Badge} from "@/components/ui/badge.tsx";
+import {
+    Form,
+    FormControl,
+    FormDescription,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from "@/components/ui/form.tsx";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select.tsx";
+import {errorMessage} from "@/api";
+import {
+    DEFAULT_EMAIL_TEMPLATES,
+    EMAIL_TEMPLATE_CONFIGS,
+    EmailTemplateCollection,
+    EmailTemplateKey,
+    findMissingRequiredVariables,
+    findUnknownVariables,
+    previewEmailTemplate,
+    saveEmailTemplate,
+    testSendEmailTemplate,
+    fetchEmailTemplates,
+} from "@/api/email-templates-stub.ts";
+
+const templateSchema = z.object({
+    subject: z.string().trim().min(1, "Обязательное поле"),
+    body: z.string().trim().min(1, "Обязательное поле"),
+});
+
+type TemplateFormData = z.infer<typeof templateSchema>;
+
+function toToken(name: string): string {
+    return `{{${name}}}`;
+}
+
+function EmailTemplatesSettings(props: {
+    spaceId: string;
+    spaceUrl: string;
+}) {
+    const [selectedTemplateKey, setSelectedTemplateKey] = useState<EmailTemplateKey>("welcome_user");
+    const [templates, setTemplates] = useState<EmailTemplateCollection>(DEFAULT_EMAIL_TEMPLATES);
+    const [activeField, setActiveField] = useState<"subject" | "body">("body");
+    const [previewData, setPreviewData] = useState<TemplateFormData | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isSaving, setIsSaving] = useState(false);
+    const [isPreviewLoading, setIsPreviewLoading] = useState(false);
+    const [isTestSending, setIsTestSending] = useState(false);
+
+    const subjectInputRef = useRef<HTMLInputElement | null>(null);
+    const bodyTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+    const selectedConfig = EMAIL_TEMPLATE_CONFIGS[selectedTemplateKey];
+
+    const form = useForm<TemplateFormData>({
+        reValidateMode: "onChange",
+        mode: "all",
+        resolver: zodResolver(templateSchema),
+        defaultValues: DEFAULT_EMAIL_TEMPLATES[selectedTemplateKey],
+        disabled: isLoading || isSaving || isPreviewLoading || isTestSending,
+    });
+
+    useEffect(() => {
+        let isActive = true;
+
+        async function loadTemplates() {
+            if (!props.spaceId) {
+                setIsLoading(false);
+                return;
+            }
+
+            setIsLoading(true);
+            try {
+                const response = await fetchEmailTemplates(props.spaceId);
+                if (!isActive) {
+                    return;
+                }
+                setTemplates(response);
+            } catch (error) {
+                if (isActive) {
+                    toast.error("Ошибка загрузки шаблонов", {description: errorMessage(error)});
+                }
+            } finally {
+                if (isActive) {
+                    setIsLoading(false);
+                }
+            }
+        }
+
+        loadTemplates();
+        return () => {
+            isActive = false;
+        };
+    }, [props.spaceId]);
+
+    useEffect(() => {
+        form.reset(templates[selectedTemplateKey]);
+        setPreviewData(null);
+    }, [form, selectedTemplateKey, templates]);
+
+    const watchedSubject = form.watch("subject");
+    const watchedBody = form.watch("body");
+
+    const missingRequiredVariables = useMemo(() => {
+        return findMissingRequiredVariables({
+            subject: watchedSubject,
+            body: watchedBody,
+            requiredVariables: selectedConfig.requiredVariables,
+        });
+    }, [selectedConfig.requiredVariables, watchedBody, watchedSubject]);
+
+    const unknownVariables = useMemo(() => {
+        return findUnknownVariables({
+            subject: watchedSubject,
+            body: watchedBody,
+            availableVariables: selectedConfig.availableVariables,
+        });
+    }, [selectedConfig.availableVariables, watchedBody, watchedSubject]);
+
+    function insertVariable(variableName: string) {
+        const token = toToken(variableName);
+        const targetName = activeField;
+        const targetRef = targetName === "subject" ? subjectInputRef.current : bodyTextareaRef.current;
+        const currentValue = form.getValues(targetName);
+
+        if (!targetRef) {
+            form.setValue(targetName, `${currentValue}${token}`, {
+                shouldDirty: true,
+                shouldValidate: true,
+            });
+            return;
+        }
+
+        const start = targetRef.selectionStart ?? currentValue.length;
+        const end = targetRef.selectionEnd ?? currentValue.length;
+        const nextValue = `${currentValue.slice(0, start)}${token}${currentValue.slice(end)}`;
+
+        form.setValue(targetName, nextValue, {
+            shouldDirty: true,
+            shouldValidate: true,
+        });
+
+        requestAnimationFrame(() => {
+            targetRef.focus();
+            const caretPosition = start + token.length;
+            targetRef.setSelectionRange(caretPosition, caretPosition);
+        });
+    }
+
+    function validateTemplateForSave(values: TemplateFormData): boolean {
+        form.clearErrors("body");
+
+        const missingRequired = findMissingRequiredVariables({
+            subject: values.subject,
+            body: values.body,
+            requiredVariables: selectedConfig.requiredVariables,
+        });
+
+        if (missingRequired.length > 0) {
+            form.setError("body", {
+                type: "manual",
+                message: `Добавьте обязательные переменные: ${missingRequired.map(toToken).join(", ")}`,
+            });
+            return false;
+        }
+
+        const unknown = findUnknownVariables({
+            subject: values.subject,
+            body: values.body,
+            availableVariables: selectedConfig.availableVariables,
+        });
+        if (unknown.length > 0) {
+            form.setError("body", {
+                type: "manual",
+                message: `Неизвестные переменные: ${unknown.map(toToken).join(", ")}`,
+            });
+            return false;
+        }
+
+        return true;
+    }
+
+    const saveHandler = form.handleSubmit(async (values) => {
+        if (!validateTemplateForSave(values)) {
+            return;
+        }
+
+        setIsSaving(true);
+        try {
+            const savedTemplate = await saveEmailTemplate({
+                spaceId: props.spaceId,
+                key: selectedTemplateKey,
+                template: values,
+            });
+            setTemplates((prev) => ({
+                ...prev,
+                [selectedTemplateKey]: savedTemplate,
+            }));
+            toast.success("Шаблон сохранен");
+        } catch (error) {
+            toast.error("Ошибка сохранения шаблона", {description: errorMessage(error)});
+        } finally {
+            setIsSaving(false);
+        }
+    });
+
+    async function previewHandler() {
+        const isValid = await form.trigger(["subject", "body"]);
+        if (!isValid) {
+            return;
+        }
+
+        const values = form.getValues();
+        const unknown = findUnknownVariables({
+            subject: values.subject,
+            body: values.body,
+            availableVariables: selectedConfig.availableVariables,
+        });
+        if (unknown.length > 0) {
+            form.setError("body", {
+                type: "manual",
+                message: `Неизвестные переменные: ${unknown.map(toToken).join(", ")}`,
+            });
+            return;
+        }
+
+        setIsPreviewLoading(true);
+        try {
+            const preview = await previewEmailTemplate({
+                key: selectedTemplateKey,
+                template: values,
+                context: {
+                    space_url: props.spaceUrl,
+                },
+            });
+            setPreviewData(preview);
+        } catch (error) {
+            toast.error("Ошибка предпросмотра", {description: errorMessage(error)});
+        } finally {
+            setIsPreviewLoading(false);
+        }
+    }
+
+    async function testSendHandler() {
+        const isValid = await form.trigger(["subject", "body"]);
+        if (!isValid) {
+            return;
+        }
+
+        const values = form.getValues();
+        if (!validateTemplateForSave(values)) {
+            return;
+        }
+
+        setIsTestSending(true);
+        try {
+            const response = await testSendEmailTemplate({
+                key: selectedTemplateKey,
+                template: values,
+                context: {
+                    space_url: props.spaceUrl,
+                },
+            });
+            toast.success(`Тестовая отправка выполнена (${response.recipient})`);
+        } catch (error) {
+            toast.error("Ошибка тестовой отправки", {description: errorMessage(error)});
+        } finally {
+            setIsTestSending(false);
+        }
+    }
+
+    return (
+        <Card className="w-full">
+            <CardHeader>
+                Шаблоны писем
+            </CardHeader>
+            <CardContent>
+                <Form {...form}>
+                    <form onSubmit={saveHandler} className="space-y-4">
+                        <FormItem>
+                            <FormLabel>Тип шаблона</FormLabel>
+                            <Select
+                                value={selectedTemplateKey}
+                                onValueChange={(value: EmailTemplateKey) => setSelectedTemplateKey(value)}
+                                disabled={isLoading}
+                            >
+                                <FormControl>
+                                    <SelectTrigger>
+                                        <SelectValue placeholder="Выберите шаблон"/>
+                                    </SelectTrigger>
+                                </FormControl>
+                                <SelectContent>
+                                    <SelectItem value="welcome_user">welcome_user</SelectItem>
+                                    <SelectItem value="password_changed">password_changed</SelectItem>
+                                </SelectContent>
+                            </Select>
+                            <FormDescription>{selectedConfig.description}</FormDescription>
+                        </FormItem>
+
+                        <div className="space-y-2">
+                            <FormLabel>Доступные переменные</FormLabel>
+                            <FormDescription>
+                                Нажмите на переменную, она вставится в текущее поле (тема или тело).
+                            </FormDescription>
+                            <div className="flex flex-wrap gap-2">
+                                {selectedConfig.availableVariables.map((variableName) => (
+                                    <Button
+                                        key={variableName}
+                                        type="button"
+                                        size="sm"
+                                        variant="outline"
+                                        onClick={() => insertVariable(variableName)}
+                                        disabled={isLoading}
+                                    >
+                                        {toToken(variableName)}
+                                    </Button>
+                                ))}
+                            </div>
+                            <div className="flex flex-wrap gap-2">
+                                <Badge variant="secondary">
+                                    Обязательные: {selectedConfig.requiredVariables.map(toToken).join(", ")}
+                                </Badge>
+                                {missingRequiredVariables.length > 0 && (
+                                    <Badge variant="destructive">
+                                        Не хватает: {missingRequiredVariables.map(toToken).join(", ")}
+                                    </Badge>
+                                )}
+                            </div>
+                        </div>
+
+                        <FormField
+                            control={form.control}
+                            name="subject"
+                            render={({field}) => (
+                                <FormItem>
+                                    <FormLabel>Тема письма</FormLabel>
+                                    <FormControl>
+                                        <Input
+                                            {...field}
+                                            onFocus={() => setActiveField("subject")}
+                                            ref={(element) => {
+                                                field.ref(element);
+                                                subjectInputRef.current = element;
+                                            }}
+                                        />
+                                    </FormControl>
+                                    <FormMessage/>
+                                </FormItem>
+                            )}
+                        />
+
+                        <FormField
+                            control={form.control}
+                            name="body"
+                            render={({field}) => (
+                                <FormItem>
+                                    <FormLabel>Тело письма</FormLabel>
+                                    <FormControl>
+                                        <textarea
+                                            {...field}
+                                            rows={8}
+                                            onFocus={() => setActiveField("body")}
+                                            ref={(element) => {
+                                                field.ref(element);
+                                                bodyTextareaRef.current = element;
+                                            }}
+                                            className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
+                                        />
+                                    </FormControl>
+                                    <FormMessage/>
+                                </FormItem>
+                            )}
+                        />
+
+                        {unknownVariables.length > 0 && (
+                            <div className="text-sm text-destructive">
+                                Неизвестные переменные: {unknownVariables.map(toToken).join(", ")}
+                            </div>
+                        )}
+
+                        <div className="flex flex-wrap gap-2">
+                            <Button
+                                type="button"
+                                variant="outline"
+                                onClick={previewHandler}
+                                disabled={isLoading || isPreviewLoading}
+                            >
+                                {isPreviewLoading && <Loader2 className="animate-spin"/>}
+                                Предпросмотр
+                            </Button>
+                            <Button
+                                type="button"
+                                variant="outline"
+                                onClick={testSendHandler}
+                                disabled={isLoading || isTestSending}
+                            >
+                                {isTestSending && <Loader2 className="animate-spin"/>}
+                                Тестовая отправка
+                            </Button>
+                            <Button type="submit" disabled={isLoading || isSaving}>
+                                {isSaving && <Loader2 className="animate-spin"/>}
+                                Сохранить шаблон
+                            </Button>
+                        </div>
+                    </form>
+                </Form>
+
+                {previewData && (
+                    <div className="mt-6 space-y-2">
+                        <div className="font-medium">Предпросмотр</div>
+                        <div className="rounded border bg-muted/50 p-3">
+                            <div className="text-sm font-medium">Тема</div>
+                            <div className="mt-1 whitespace-pre-wrap break-words text-sm">{previewData.subject}</div>
+                        </div>
+                        <div className="rounded border bg-muted/50 p-3">
+                            <div className="text-sm font-medium">Тело</div>
+                            <div className="mt-1 whitespace-pre-wrap break-words text-sm">{previewData.body}</div>
+                        </div>
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+}
+
+export default EmailTemplatesSettings;

--- a/frontend/src/routes/spaces/dashboard/settings/SettingsPage.tsx
+++ b/frontend/src/routes/spaces/dashboard/settings/SettingsPage.tsx
@@ -18,13 +18,16 @@ import {
     $smtpSettings,
     $selectedSpaceId,
     ApiSmtpSettingsModel,
-    $spacesQueryOptions, $spaces, $selectedSpace, ApiSpaceModel, $roomsQueryOptions, $smtpSettingsQueryOptions
+    $selectedSpace,
+    ApiSpaceModel,
+    $smtpSettingsQueryOptions
 } from "@/store/global-store.ts";
 import {useAtomValue} from "jotai/index";
 import {BatchLoader} from "@/components/app/DataLoader.tsx";
 import {Loader2} from "lucide-react";
 import {registerSchema} from "@/lib/form.ts";
 import {useInvalidateSpace} from "@/api/invalidate.ts";
+import EmailTemplatesSettings from "@/routes/spaces/dashboard/settings/EmailTemplatesSettings.tsx";
 
 
 const smtpSettingsSchema = z.object({
@@ -354,16 +357,22 @@ function SettingsPageContent(props: {
     space: ApiSpaceModel
 }) {
     return (
-        <div className="flex flex-col m-6 h-screen max-w-screen-lg w-screen py-4 ml-6">
+        <div className="flex flex-col max-w-[1160px] w-full p-4">
             <span className="text-4xl">Настройки</span>
 
-            <div className="mt-6 flex space-x-6 w-full">
+            <div className="mt-6 flex flex-wrap gap-6 w-full">
                 <div className="w-[550px]">
                     <SMTPSettingsContent smtpSettings={props.smtpSetting}/>
                 </div>
                 <div className="w-[550px]">
                     <EditSpaceContent space={props.space}/>
                 </div>
+            </div>
+            <div className="mt-6 w-full">
+                <EmailTemplatesSettings
+                    spaceId={props.space._id ?? ""}
+                    spaceUrl={String(props.space.url)}
+                />
             </div>
         </div>
     )


### PR DESCRIPTION
Что было сделано:
 1. Добавлен UI-компонент EmailTemplatesSettings.tsx. 
     Зачем: дать в Settings отдельный экран для управления шаблонами писем (редактирование темы/тела, предпросмотр,  тестовая отправка, валидация переменных).
 2. Добавлен временный API-слой email-templates-stub.ts.
     Зачем: фронт может работать и тестироваться до реализации backend endpoint’ов;
 3. Добавлены новые модели для email templates в backend models.py. 
     Зачем: зафиксировать единый контракт между фронтом и бэком для CRUD.