### PR TITLE
Issue 177: Update docker images

### DIFF
--- a/deployment/dev/docker-compose.yaml
+++ b/deployment/dev/docker-compose.yaml
@@ -1,10 +1,10 @@
 volumes:
-  mongodb_data: 
+  mongodb_data:
     driver: local
 
 services:
   rocketchat:
-    image: registry.rocket.chat/rocketchat/rocket.chat:latest
+    image: registry.rocket.chat/rocketchat/rocket.chat:7.13.5
     restart: always
     environment:
       MONGO_URL: "mongodb://mongodb:27017/rocketchat"
@@ -33,7 +33,7 @@ services:
     restart: always
     volumes:
       - mongodb_data:/data/db
-    ports: 
+    ports:
       - "0.0.0.0:27017:27017"
     healthcheck:
       test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet

--- a/deployment/dev/docker-compose.yaml
+++ b/deployment/dev/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
       start_period: 10s
 
   mongodb:
-    image: mongo:6.0.5
+    image: mongo:7.0.31
     restart: always
     volumes:
       - mongodb_data:/data/db

--- a/deployment/prod/docker-compose.yaml
+++ b/deployment/prod/docker-compose.yaml
@@ -3,7 +3,6 @@ volumes:
     driver: local
 
 services:
-
   frontend:
     build:
       context: ../../frontend
@@ -38,7 +37,7 @@ services:
       start_period: 20s
 
   mongodb:
-    image: mongo:6.0.5
+    image: mongo:7.0.31
     restart: always
     volumes:
       - mongodb_data:/data/db


### PR DESCRIPTION
Закрывает #177.
Что было сделано:
- Меняет версию образа RocketChat с latest на 7.13.5
- Обновляет верисю образа MongoDB с 6.0.5 до 7.0.31 (*)

(*) Необходима ручная миграция для продовых контейнеров с MongoDB. Инструкции [тут](https://github.com/moevm/rocket-administration-app/issues/177#issuecomment-4150636973).