### PR TITLE
Mongo replica-set

### DIFF
--- a/backend/settings.yaml
+++ b/backend/settings.yaml
@@ -1,5 +1,5 @@
 mongo:
-  uri: mongodb://localhost:27017
+  uri: mongodb://localhost:27017?replicaSet=rs0
   database: rocketmanager
 
 app:

--- a/deployment/dev/docker-compose.yaml
+++ b/deployment/dev/docker-compose.yaml
@@ -6,10 +6,10 @@ volumes:
 
 services:
   rocketchat:
-    image: registry.rocket.chat/rocketchat/rocket.chat:7.13.5
-    restart: always
+    image: rocket.chat:8
+    restart: unless-stopped
     environment:
-      MONGO_URL: "mongodb://mongodb:27017/rocketchat"
+      MONGO_URL: "mongodb://mongodb:27017/rocketchat?replicaSet=rs0"
       ROOT_URL: http://localhost:3000
       PORT: 3000
       DEPLOY_METHOD: docker
@@ -19,35 +19,50 @@ services:
     depends_on:
       mongodb:
         condition: service_healthy
+      mongodb-bootstrap:
+        condition: service_completed_successfully
     expose:
       - 3000
     ports:
       - "0.0.0.0:3000:3000"
     healthcheck:
-      test: [ "CMD-SHELL", "/usr/bin/wget --no-verbose --tries=1 -S --spider 127.0.0.1:3000/ || exit 1" ]
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:3000/api/info', (r) => process.exit(r.statusCode === 200 ? 0 : 1))"]
       interval: 30s
       timeout: 10s
       retries: 5
       start_period: 10s
 
   mongodb:
-    image: mongo:7.0.31
-    restart: always
+    image: mongo:8
+    restart: unless-stopped
     volumes:
       - mongodb_data:/data/db
+    command: [ "--replSet", "rs0", "--bind_ip_all" ]
     ports:
       - "0.0.0.0:27017:27017"
     healthcheck:
-      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet
-      interval: 10s
-      timeout: 10s
-      retries: 5
-      start_period: 20s
+      test: [ "CMD", "mongosh", "--quiet", "--eval", "db.runCommand({ ping: 1 })" ]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  # One-shot контейнер для инициализации MongoDB в режиме replica set
+  mongodb-bootstrap:
+    image: mongo:8
+    restart: no
+    depends_on:
+      mongodb:
+        condition: service_healthy
+    volumes:
+      - ../../mongodb/bootstrap:/bootstrap:ro
+    entrypoint: [ "/bin/bash" ]
+    command: [ "/bootstrap/init.sh" ]
 
   # https://github.com/bitnami/containers/issues/83267
   # Альтернатива - https://github.com/nfrastack/container-openldap
   openldap:
-    image: nfrastack/openldap:2.6-8.0.2
+    image: nfrastack/openldap:2.6
     restart: unless-stopped
     ports:
       - "0.0.0.0:8389:389"
@@ -73,7 +88,7 @@ services:
 
   # One-shot контейнер для инициализации openldap данными из init.ldif
   openldap-bootstrap:
-    image: nfrastack/openldap:2.6-8.0.2
+    image: nfrastack/openldap:2.6
     restart: no
     environment:
       - TZ=Europe/Moscow

--- a/deployment/prod/docker-compose.yaml
+++ b/deployment/prod/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
     ports:
       - "${FRONTEND_PORT}:80"
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://frontend:80"]
+      test: [ "CMD", "wget", "--spider", "-q", "http://frontend:80" ]
       interval: 30s
       timeout: 5s
       retries: 5
@@ -22,28 +22,44 @@ services:
     build: ../../backend
     restart: unless-stopped
     environment:
-      ROCKETAPP_MONGO__URI: mongodb://mongodb:27017
+      ROCKETAPP_MONGO__URI: mongodb://mongodb:27017?replicaSet=rs0
       ROCKETAPP_MONGO__DATABASE: rocketappdb
     depends_on:
       mongodb:
         condition: service_healthy
+      mongodb-bootstrap:
+        condition: service_completed_successfully
     ports:
       - "127.0.0.1:${BACKEND_PORT}:8000"
     healthcheck:
-      test: ["CMD", "wget", "-q", "http://backend:8000/_health", "-O", "/dev/null"]
+      test: [ "CMD", "wget", "-q", "http://backend:8000/_health", "-O", "/dev/null" ]
       interval: 30s
       timeout: 10s
       retries: 5
       start_period: 20s
 
   mongodb:
-    image: mongo:7.0.31
-    restart: always
+    image: mongo:8
+    restart: unless-stopped
     volumes:
       - mongodb_data:/data/db
+    command: [ "--replSet", "rs0", "--bind_ip_all" ]
     healthcheck:
-      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/test --quiet
-      interval: 10s
-      timeout: 10s
-      retries: 5
-      start_period: 20s
+      test: [ "CMD", "mongosh", "--quiet", "--eval", "db.runCommand({ ping: 1 })" ]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  # One-shot контейнер для инициализации MongoDB в режиме replica set
+  mongodb-bootstrap:
+    image: mongo:8
+    restart: no
+    depends_on:
+      mongodb:
+        condition: service_healthy
+    volumes:
+      - ../../mongodb/bootstrap:/bootstrap:ro
+    entrypoint: [ "/bin/bash" ]
+    command: [ "/bootstrap/init.sh" ]
+

--- a/mongodb/bootstrap/init.sh
+++ b/mongodb/bootstrap/init.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+until mongosh --host mongodb:27017 --eval 'db.runCommand({ ping: 1 })' >/dev/null 2>&1; do
+  sleep 2
+done
+
+mongosh --host mongodb:27017 --eval '
+try {
+  rs.status()
+} catch (e) {
+  rs.initiate({
+    _id: "rs0",
+    members: [{ _id: 0, host: "mongodb:27017" }]
+  })
+}
+'


### PR DESCRIPTION
Что было сделано:
- Меняет конфигурацию запуска Mongo, теперь запускается в режиме replica-set из одной ноды
- Обновляет версии образов RocketChat и Mongo до 8 (нужно пересоздать контейнеры)