### PR TITLE
166 update template

### DIFF
--- a/backend/app/features/settings/router.py
+++ b/backend/app/features/settings/router.py
@@ -2,11 +2,30 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from app.features.spaces.utils import get_space
 from app.lib.smtp import validate_config
-from app.models import SmtpSettingsResponseDto, SmtpSettingsDto
+from app.lib.email_templates import (
+    get_templates,
+    save_template,
+    preview_template,
+    validate_template_variables
+)
+from app.models import (
+    SmtpSettingsResponseDto, 
+    SmtpSettingsDto,
+    EmailTemplateUpsertDto,
+    EmailTemplateDto,
+    EmailTemplatePreviewRequestDto,
+    EmailTemplatePreviewResponseDto,
+    EmailTemplateTestSendRequestDto,
+    EmailTemplateTestSendResponseDto,
+    EmailTemplatesMapDto
+)
 from app.services.db import get_db
 from app.lib import smtp
+import logging
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
+
 
 @router.get("/smtp")
 async def get_smtp_settings(space=Depends(get_space), db=Depends(get_db)) -> SmtpSettingsResponseDto:
@@ -19,5 +38,79 @@ async def set_smtp_settings(request: SmtpSettingsDto, space=Depends(get_space), 
     await smtp.set_smtp_settings(db, space.id, request)
 
 
+@router.get("/email-templates", response_model=EmailTemplatesMapDto)
+async def get_email_templates(space=Depends(get_space), db=Depends(get_db)):
+    templates = await get_templates(db, space.id)
 
+    welcome_template = EmailTemplateDto(
+        key="welcome_user",
+        subject=templates.get("welcome_user", {}).get("subject", ""),
+        body=templates.get("welcome_user", {}).get("body", "")
+    )
+    
+    password_template = EmailTemplateDto(
+        key="password_changed",
+        subject=templates.get("password_changed", {}).get("subject", ""),
+        body=templates.get("password_changed", {}).get("body", "")
+    )
+    
+    return EmailTemplatesMapDto(
+        welcome_user=welcome_template,
+        password_changed=password_template
+    )
 
+@router.put("/email-templates/{key}")
+async def update_email_template(
+    key: str,
+    template_data: EmailTemplateUpsertDto,
+    space=Depends(get_space), 
+    db=Depends(get_db)
+):    
+    if key not in ["welcome_user", "password_changed"]:
+        raise HTTPException(status_code=400, detail="Invalid template key")
+
+    await validate_template_variables(key, template_data.subject, template_data.body)
+    saved = await save_template(db, space.id, key, template_data)
+    
+    return EmailTemplateDto(
+        key=key,
+        subject=saved.subject,
+        body=saved.body
+    )
+
+@router.post("/email-templates/preview", response_model=EmailTemplatePreviewResponseDto)
+async def preview_email_template(
+    request: EmailTemplatePreviewRequestDto
+):
+    subject, body = await preview_template(
+        template=request.template,
+        context=request.context or {}
+    )
+    return EmailTemplatePreviewResponseDto(subject=subject, body=body)
+
+@router.post("/email-templates/test-send", response_model=EmailTemplateTestSendResponseDto)
+async def test_send_email_template(
+    request: EmailTemplateTestSendRequestDto,
+    space=Depends(get_space),
+    db=Depends(get_db)
+):
+    smtp_config = await smtp.get_smtp_settings(db, space.id)
+    if not smtp_config:
+        raise HTTPException(status_code=400, detail="SMTP settings not configured")
+
+    subject, body = await preview_template(
+        template=request.template,
+        context=request.context or {}
+    )
+    
+    message_id = await smtp.send_email(
+        config=smtp_config,
+        to=request.to,
+        subject=subject,
+        body=body
+    )
+    
+    return EmailTemplateTestSendResponseDto(
+        recipient=request.to,
+        message_id=message_id
+    )

--- a/backend/app/features/users/router.py
+++ b/backend/app/features/users/router.py
@@ -7,11 +7,12 @@ from app.lib.cache import key_for_space
 from app.models import UserDto, TeamDto, UserInfoDto, UsersToChangePasswordDto,\
     ChangedPasswordDto, UsersImportRequestDto, ImportedUserResultDto, UserCreateDto, \
     UsersDeleteDto, UserDeleteResDto, UpdateUserRequest
-from typing import Optional, List
+from typing import List
 from app.features.spaces.utils import get_space
 from app.lib.rocket import obtain_rocket_instance, rocket_request, rocket_query_args
 from app.lib.utils import batch_execute, generate_password, extract_exception_message
 from app.lib.smtp import send_email, require_smtp_settings
+from app.services.email_service import EmailService
 from app.services.db import get_db
 from app.config import settings
 import logging
@@ -57,18 +58,29 @@ async def get_user_information(user_id: str, space=Depends(get_space)) -> UserIn
 
 
 @router.post("/change-passwords")
-async def change_user_passwords(body: UsersToChangePasswordDto, space=Depends(get_space), db=Depends(get_db)) -> List[ChangedPasswordDto]:
+async def change_user_passwords(
+    body: UsersToChangePasswordDto, 
+    space=Depends(get_space), 
+    db=Depends(get_db)
+) -> List[ChangedPasswordDto]:
     rocket = await obtain_rocket_instance(key_for_space(space))
 
+    smtp_settings = None
+    email_service = None
+    
     if body.sendEmail:
         smtp_settings = await require_smtp_settings(db, space.id)
+        email_service = EmailService(db, space.id)
 
     async def _process(user: str, password_to_set: str):
         result = ChangedPasswordDto(user=user)        
         try:
-            await rocket_request(rocket.users_update, **rocket_query_args(user_id=user, password=password_to_set))
+            await rocket_request(
+                rocket.users_update, 
+                **rocket_query_args(user_id=user, password=password_to_set)
+            )
         except Exception as e:
-            print(e)
+            logger.error(f"Failed to change password for {user}: {e}")
             result.password_error = extract_exception_message(e)
         else:
             result.password = password_to_set
@@ -77,20 +89,31 @@ async def change_user_passwords(body: UsersToChangePasswordDto, space=Depends(ge
             return result
         
         try:
-            user_info = await rocket_request(rocket.users_info, **rocket_query_args(user_id=user))
-            if len(user_info["user"]['emails']) == 0:
+            user_info = await rocket_request(
+                rocket.users_info, 
+                **rocket_query_args(user_id=user)
+            )
+            
+            if not user_info["user"].get('emails') or len(user_info["user"]['emails']) == 0:
                 result.email_send_error = "У пользователя нет адресов электронной почты"
                 return result
-            await send_email(
-                smtp_settings,
-                user_info["user"]['emails'][0]["address"],
-                "Пароль изменен",
-                f"Ваш новый пароль в пространстве {space.url}: {password_to_set}"
+            
+            user_email = user_info["user"]['emails'][0]["address"]
+            username = user_info["user"].get("username", user)
+
+            message_id = await email_service.send_password_changed_email(
+                to_email=user_email,
+                username=username,
+                password=password_to_set,
+                space_url=str(space.url)
             )
+            result.email_sent = True
+            logger.info(f"Password changed email sent to {user_email}, message_id: {message_id}")
+            
         except Exception as e:
             result.email_send_error = extract_exception_message(e)
-        else:
-            result.email_sent = True
+            logger.error(f"ERROR!! Failed to send password change email: {e}")
+            
         return result
 
     args_for_batch = []
@@ -115,8 +138,13 @@ async def create_users(
 ) -> List[ImportedUserResultDto]:
     rocket = await obtain_rocket_instance(key_for_space(space))
 
+    email_service = None
     if body.sendEmail:
-        smtp_settings = await require_smtp_settings(db, space.id)
+        try:
+            await require_smtp_settings(db, space.id)
+            email_service = EmailService(db, space.id)
+        except HTTPException as e:
+            logger.warning(f"SMTP not configured! Error: {e.detail}")
 
     async def _process_user_creation(user_data: UserCreateDto):
         if user_data.password and user_data.password.strip():
@@ -155,17 +183,26 @@ async def create_users(
         except Exception as e:
             result.error = extract_exception_message(e)
 
-        if body.sendEmail and result.created_id:
+        if body.sendEmail and result.created_id and not result.error and email_service:
             try:
-                await send_email(
-                    smtp_settings,
-                    user_data.email,
-                    f"Ваш аккаунт в {space.url} создан",
-                    f"Добро пожаловать!\n\nВаш временный пароль для входа в пространство {space.url}:\n{password}\n\nРекомендуем сменить его после первого входа."
+                logger.info(f"Attempting to send welcome email to {user_data.email}")
+                
+                message_id = await email_service.send_welcome_email(
+                    to_email=user_data.email,
+                    username=user_data.username,
+                    password=password,
+                    space_url=str(space.url)
                 )
                 result.email_sent = True
             except Exception as e:
                 result.email_error = f"Ошибка отправки email: {extract_exception_message(e)}"
+        else:
+            if not body.sendEmail:
+                logger.info(f"Email sending disabled for user {user_data.username}")
+            elif not email_service:
+                logger.warning(f"Email service not available for user {user_data.username}")
+            elif result.error:
+                logger.warning(f"User creation failed for {user_data.username}, skipping email")
 
         return result
 

--- a/backend/app/lib/email_templates.py
+++ b/backend/app/lib/email_templates.py
@@ -1,0 +1,161 @@
+import re
+from typing import Dict, Optional, Tuple, Any
+from datetime import datetime
+from fastapi import HTTPException
+from pymongo.asynchronous.database import AsyncDatabase
+import logging
+
+logger = logging.getLogger(__name__)
+
+from app.models import EmailTemplateUpsertDto
+
+TOKEN_PATTERN = re.compile(r"{{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*}}")
+
+DEFAULT_TEMPLATES = {
+    "welcome_user": {
+        "subject": "Ваш аккаунт в {{space_url}} создан",
+        "body": """<div>
+            <h2>Добро пожаловать, {{username}}!</h2>
+            <p>Ваш аккаунт успешно создан.</p>
+            <p><strong>Временный пароль:</strong> {{password}}</p>
+            <p><strong>Пространство:</strong> <a href="{{space_url}}">{{space_url}}</a></p>
+        </div>"""
+    },
+    "password_changed": {
+        "subject": "Пароль изменен в {{space_url}}",
+        "body": """<div>
+            <h2>Здравствуйте, {{username}}!</h2>
+            <p>Ваш пароль был изменен.</p>
+            <p><strong>Новый пароль:</strong> {{password}}</p>
+            <p><strong>Пространство:</strong> <a href="{{space_url}}">{{space_url}}</a></p>
+        </div>"""
+    }
+}
+
+TEMPLATE_CONFIGS = {
+    "welcome_user": {
+        "available_variables": ["username", "space_url", "password"],
+        "required_variables": ["space_url", "password"]
+    },
+    "password_changed": {
+        "available_variables": ["username", "space_url", "password"],
+        "required_variables": ["space_url", "password"]
+    }
+}
+
+def extract_variables(content: str) -> list[str]:
+    if not content:
+        return []
+    return [match.group(1) for match in TOKEN_PATTERN.finditer(content)]
+
+def render_template(template: str, context: Dict[str, str]) -> str:
+    if not template:
+        return ""
+    
+    def replace(match):
+        var = match.group(1)
+        return context.get(var, match.group(0))
+    
+    return TOKEN_PATTERN.sub(replace, template)
+
+async def validate_template_variables(key: str, subject: str, body: str):
+    config = TEMPLATE_CONFIGS.get(key)
+    if not config:
+        return
+    
+    full_content = f"{subject or ''}\n{body or ''}"
+    used_vars = set(extract_variables(full_content))
+
+    missing = [v for v in config["required_variables"] if v not in used_vars]
+    if missing:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Missing required variables: {', '.join(missing)}"
+        )
+    
+    unknown = [v for v in used_vars if v not in config["available_variables"]]
+    if unknown:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown variables: {', '.join(unknown)}"
+        )
+
+async def get_templates(db: AsyncDatabase, space_id: str) -> Dict:
+    settings_collection = db.settings
+    settings = await settings_collection.find_one({"space_id": space_id})
+    
+    saved_templates = {}
+    if settings:
+        saved_templates = settings.get("email_templates", {})
+    else:
+        logger.warning(f"No settings document found for space {space_id}, will use defaults")
+
+        await settings_collection.update_one(
+            {"space_id": space_id},
+            {"$set": {"space_id": space_id, "created_at": datetime.utcnow()}},
+            upsert=True
+        )
+
+    result = {}
+    for key in DEFAULT_TEMPLATES:
+        if key in saved_templates:
+            result[key] = saved_templates[key]
+            logger.debug(f"Using saved template for {key}")
+        else:
+            result[key] = DEFAULT_TEMPLATES[key]
+            logger.debug(f"Using default template for {key}")
+    
+    return result
+
+
+async def save_template(
+    db: AsyncDatabase, 
+    space_id: str, 
+    key: str, 
+    template: EmailTemplateUpsertDto
+) -> EmailTemplateUpsertDto:
+    settings_collection = db.settings
+    
+    existing = await settings_collection.find_one({"space_id": space_id})
+    logger.info(f"Existing settings document: {existing is not None}")
+
+    update_data = {
+        "$set": {
+            f"email_templates.{key}": {
+                "subject": template.subject,
+                "body": template.body
+            },
+            "updated_at": datetime.utcnow(),
+            "space_id": space_id
+        }
+    }
+
+    result = await settings_collection.update_one(
+        {"space_id": space_id},
+        update_data,
+        upsert=True
+    )
+
+    saved = await settings_collection.find_one({"space_id": space_id})
+    if saved:
+        logger.info(f"Saved templates keys: {list(saved.get('email_templates', {}).keys())}")
+    else:
+        logger.error("Failed to save! No document found after update! nooooo")
+    
+    return template
+
+async def preview_template(
+    template: EmailTemplateUpsertDto,
+    context: Optional[Dict[str, str]] = None
+) -> Tuple[str, str]:
+    sample_context = {
+        "username": "test_user",
+        "space_url": "https://example.space",
+        "password": "IplayPokemonGoeveryday",
+        **(context or {})
+    }
+    
+    subject = render_template(template.subject, sample_context)
+    body = render_template(template.body, sample_context)
+    
+    return subject, body

--- a/backend/app/lib/smtp.py
+++ b/backend/app/lib/smtp.py
@@ -1,38 +1,65 @@
 from fastapi import HTTPException
 from typing import Optional
-from urllib.parse import unquote
-
+from urllib.parse import urlparse, unquote
 from app.models import SmtpSettingsDto
 from aiosmtplib import SMTP
 from pymongo.asynchronous.database import AsyncDatabase
 from email.message import EmailMessage
+import logging
 
+logger = logging.getLogger(__name__)
 
-def _get_credentials(config: SmtpSettingsDto) -> tuple[str, str]:
+def parse_smtp_url(url: str) -> tuple[str, int, str, str]:
+    parsed = urlparse(url)
+    
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 587
+    username = unquote(parsed.username) if parsed.username else None
+    password = unquote(parsed.password) if parsed.password else None
+    
+    return host, port, username, password
+
+def _get_credentials(config: SmtpSettingsDto) -> tuple[Optional[str], Optional[str]]:
     """
-    Деэкранирует имя пользователя и пароль из конфигурации SMTP, если они присутствуют.
+    Извлекает и деэкранирует имя пользователя и пароль из конфигурации SMTP.
+    Поддерживает оба формата: отдельные поля или URL с credentials.
     """
-    username = unquote(config.host.username) if config.host.username else ""
-    password = unquote(config.host.password) if config.host.password else ""
+    if hasattr(config.host, 'username') and config.host.username:
+        username = unquote(config.host.username)
+        password = unquote(config.host.password) if config.host.password else ""
+        return username, password
+
+    host_str = str(config.host)
+    _, _, username, password = parse_smtp_url(host_str)
     return username, password
-
 
 async def validate_config(config: SmtpSettingsDto):
     username, password = _get_credentials(config)
-    smtp = SMTP(hostname=config.host.host, port=config.host.port, use_tls=config.use_tls)
+
+    host_str = str(config.host)
+    if hasattr(config.host, 'host'):
+        host = config.host.host
+        port = config.host.port or 587
+    else:
+        host, port, _, _ = parse_smtp_url(host_str)
+    
+    smtp = SMTP(hostname=host, port=port, use_tls=config.use_tls)
     try:
         await smtp.connect()
+        logger.info(f"SMTP connection successful to {host}:{port}")
     except Exception as e:
-        print(e)
+        logger.error(f"SMTP connection failed: {e}")
         raise HTTPException(status_code=400, detail="Ошибка подключения к SMTP-серверу")
-    try:
-        await smtp.login(username, password)
-    except Exception as e:
-        print(e)
-        raise HTTPException(status_code=400, detail="Ошибка авторизации SMTP-сервера")
-
+    
+    if username and password:
+        try:
+            await smtp.login(username, password)
+            logger.info(f"SMTP authentication successful for {username}")
+        except Exception as e:
+            logger.error(f"SMTP authentication failed: {e}")
+            raise HTTPException(status_code=400, detail="Ошибка авторизации SMTP-сервера")
+    
     await smtp.quit()
-
 
 async def get_smtp_settings(
     db: AsyncDatabase, space_id: str
@@ -40,9 +67,8 @@ async def get_smtp_settings(
     result = await db.smtp.find_one({"space_id": space_id})
     if result is None:
         return None
-
+    
     return SmtpSettingsDto.model_validate(result)
-
 
 async def set_smtp_settings(
     db: AsyncDatabase, space_id: str, settings: SmtpSettingsDto
@@ -63,13 +89,48 @@ async def require_smtp_settings(db: AsyncDatabase, space_id: str) -> SmtpSetting
     return settings
 
 
-async def send_email(config: SmtpSettingsDto, to: str, subject: str, message: str):
-    username, password = _get_credentials(config)
-    async with SMTP(hostname=config.host.host, port=config.host.port, use_tls=config.use_tls) as smtp:
-        await smtp.login(username, password)
-        email_message = EmailMessage()
-        email_message["From"] = config.sender
-        email_message["To"] = to
-        email_message["Subject"] = subject
-        email_message.set_content(message)
-        response = await smtp.send_message(email_message)
+async def send_email(
+    config: SmtpSettingsDto, 
+    to: str, 
+    subject: str, 
+    body: str,
+    is_html: bool = True
+) -> str:
+    try:
+        username, password = _get_credentials(config)
+        host_str = str(config.host)
+        if hasattr(config.host, 'host'):
+            host = config.host.host
+            port = config.host.port or 587
+        else:
+            host, port, _, _ = parse_smtp_url(host_str)
+        
+        logger.info(f"Sending email to {to} via {host}:{port}")
+        
+        async with SMTP(
+            hostname=host, 
+            port=port, 
+            use_tls=config.use_tls
+        ) as smtp:
+            if username and password:
+                await smtp.login(username, password)
+
+            email_message = EmailMessage()
+            email_message["From"] = str(config.sender)
+            email_message["To"] = to
+            email_message["Subject"] = subject
+
+            if is_html:
+                email_message.set_content(body, subtype="html")
+            else:
+                email_message.set_content(body)
+            response = await smtp.send_message(email_message)
+            logger.info(f"Email sent successfully to {to}")
+            return str(response)
+            
+    except Exception as e:
+        logger.error(f"Failed to send email to {to}: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=500, 
+            detail=f"Failed to send email: {str(e)}"
+        )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -379,3 +379,33 @@ class UserDeleteResDto(BaseModel):
     force_delete: bool
     success: bool = False
     error: Optional[str] = None
+
+class EmailTemplateUpsertDto(BaseModel):
+    subject: str = Field(min_length=1)
+    body: str = Field(min_length=1)
+
+class EmailTemplateDto(BaseModel):
+    key: str
+    subject: str
+    body: str
+
+class EmailTemplatesMapDto(BaseModel):
+    welcome_user: EmailTemplateDto
+    password_changed: EmailTemplateDto
+
+class EmailTemplatePreviewRequestDto(BaseModel):
+    template: EmailTemplateUpsertDto
+    context: Optional[Dict[str, str]] = None
+
+class EmailTemplatePreviewResponseDto(BaseModel):
+    subject: str
+    body: str
+
+class EmailTemplateTestSendRequestDto(BaseModel):
+    template: EmailTemplateUpsertDto
+    context: Optional[Dict[str, str]] = None
+    to: EmailStr
+
+class EmailTemplateTestSendResponseDto(BaseModel):
+    recipient: EmailStr
+    message_id: str

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -1,0 +1,87 @@
+import logging
+from typing import Dict, Optional
+from fastapi import HTTPException
+from pymongo.asynchronous.database import AsyncDatabase
+
+from app.lib.email_templates import get_templates, render_template, DEFAULT_TEMPLATES
+from app.lib import smtp
+from app.models import SmtpSettingsDto
+
+logger = logging.getLogger(__name__)
+
+class EmailService:
+    def __init__(self, db: AsyncDatabase, space_id: str):
+        self.db = db
+        self.space_id = space_id
+    
+    async def _get_smtp_config(self) -> SmtpSettingsDto:
+        smtp_config = await smtp.get_smtp_settings(self.db, self.space_id)
+        if not smtp_config:
+            raise HTTPException(
+                status_code=400, 
+                detail=f"SMTP settings not configured for space {self.space_id}"
+            )
+        return smtp_config
+
+    async def _get_template(self, template_key: str, context: Dict[str, str]) -> tuple[str, str]:
+        templates = await get_templates(self.db, self.space_id)
+        template = templates.get(template_key)
+        
+        if not template:
+            logger.warning(f"Template {template_key} not found, using default")
+            from app.lib.email_templates import DEFAULT_TEMPLATES
+            template = DEFAULT_TEMPLATES.get(template_key)
+
+        subject = render_template(template.get("subject", ""), context)
+        body = render_template(template.get("body", ""), context)
+        
+        return subject, body
+
+    async def send_welcome_email(
+        self, 
+        to_email: str, 
+        username: str, 
+        password: str, 
+        space_url: str
+    ) -> str:
+        context = {
+            "username": username,
+            "password": password,
+            "space_url": space_url
+        }
+        
+        subject, body = await self._get_template("welcome_user", context)
+
+        smtp_config = await self._get_smtp_config()
+
+        return await smtp.send_email(
+            config=smtp_config, 
+            to=to_email, 
+            subject=subject, 
+            body=body,
+            is_html=True
+        )
+    
+    async def send_password_changed_email(
+        self, 
+        to_email: str, 
+        username: str, 
+        password: str, 
+        space_url: str
+    ) -> str:
+        context = {
+            "username": username,
+            "password": password,
+            "space_url": space_url
+        }
+        
+        subject, body = await self._get_template("password_changed", context)
+        smtp_config = await self._get_smtp_config()
+
+        return await smtp.send_email(
+            config=smtp_config, 
+            to=to_email, 
+            subject=subject, 
+            body=body,
+            is_html=True
+        )

--- a/frontend/src/api/email-templates-stub.ts
+++ b/frontend/src/api/email-templates-stub.ts
@@ -16,17 +16,7 @@ export type EmailTemplateConfig = {
     sampleContext: Record<string, string>;
 };
 
-type StoredTemplates = Partial<Record<EmailTemplateKey, Partial<EmailTemplateModel>>>;
-
-const STORAGE_KEY_PREFIX = "rocket_email_templates_v1";
-
 const TOKEN_PATTERN = /{{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*}}/g;
-
-const wait = (ms: number) =>
-    new Promise<void>((resolve) => {
-        setTimeout(resolve, ms);
-    });
-
 export const EMAIL_TEMPLATE_CONFIGS: Record<EmailTemplateKey, EmailTemplateConfig> = {
     welcome_user: {
         key: "welcome_user",
@@ -65,56 +55,7 @@ export const DEFAULT_EMAIL_TEMPLATES: EmailTemplateCollection = {
     },
 };
 
-function getStorageKey(spaceId: string): string {
-    return `${STORAGE_KEY_PREFIX}:${spaceId}`;
-}
-
-function readStoredTemplates(spaceId: string): StoredTemplates {
-    if (!spaceId || typeof window === "undefined") {
-        return {};
-    }
-
-    const raw = window.localStorage.getItem(getStorageKey(spaceId));
-    if (!raw) {
-        return {};
-    }
-
-    try {
-        const parsed: unknown = JSON.parse(raw);
-        if (!parsed || typeof parsed !== "object") {
-            return {};
-        }
-        return parsed as StoredTemplates;
-    } catch {
-        return {};
-    }
-}
-
-function writeStoredTemplates(spaceId: string, templates: StoredTemplates): void {
-    if (!spaceId || typeof window === "undefined") {
-        return;
-    }
-    window.localStorage.setItem(getStorageKey(spaceId), JSON.stringify(templates));
-}
-
-function normalizeTemplate(
-    value: Partial<EmailTemplateModel> | undefined,
-    fallback: EmailTemplateModel,
-): EmailTemplateModel {
-    return {
-        subject: value?.subject ?? fallback.subject,
-        body: value?.body ?? fallback.body,
-    };
-}
-
-function renderTemplateString(template: string, context: Record<string, string>): string {
-    return template.replace(TOKEN_PATTERN, (_, variableName: string) => {
-        if (Object.prototype.hasOwnProperty.call(context, variableName)) {
-            return context[variableName];
-        }
-        return `{{${variableName}}}`;
-    });
-}
+const TOKEN_PATTERN = /{{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*}}/g;
 
 export function extractTemplateVariables(content: string): string[] {
     const regex = new RegExp(TOKEN_PATTERN.source, "g");
@@ -154,13 +95,22 @@ export function findUnknownVariables(params: {
     return usedVariables.filter((variableName) => !availableVariables.has(variableName));
 }
 
-export async function fetchEmailTemplates(spaceId: string): Promise<EmailTemplateCollection> {
-    await wait(200);
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
 
-    const stored = readStoredTemplates(spaceId);
+export async function fetchEmailTemplates(spaceId: string): Promise<EmailTemplateCollection> {
+    const response = await fetch(`${API_BASE_URL}/spaces/${spaceId}/settings/email-templates`, {
+        credentials: 'include',
+    });
+    
+    if (!response.ok) {
+        console.error(`Failed to fetch templates: ${response.status}`);
+        return DEFAULT_EMAIL_TEMPLATES;
+    }
+    
+    const data = await response.json();
     return {
-        welcome_user: normalizeTemplate(stored.welcome_user, DEFAULT_EMAIL_TEMPLATES.welcome_user),
-        password_changed: normalizeTemplate(stored.password_changed, DEFAULT_EMAIL_TEMPLATES.password_changed),
+        welcome_user: data.welcome_user || DEFAULT_EMAIL_TEMPLATES.welcome_user,
+        password_changed: data.password_changed || DEFAULT_EMAIL_TEMPLATES.password_changed,
     };
 }
 
@@ -169,16 +119,25 @@ export async function saveEmailTemplate(params: {
     key: EmailTemplateKey;
     template: EmailTemplateModel;
 }): Promise<EmailTemplateModel> {
-    await wait(250);
-
-    const stored = readStoredTemplates(params.spaceId);
-    stored[params.key] = {
-        subject: params.template.subject,
-        body: params.template.body,
-    };
-    writeStoredTemplates(params.spaceId, stored);
-
-    return params.template;
+    const response = await fetch(`${API_BASE_URL}/spaces/${params.spaceId}/settings/email-templates/${params.key}`, {
+        method: 'PUT',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+        body: JSON.stringify({
+            subject: params.template.subject,
+            body: params.template.body,
+        }),
+    });
+    
+    if (!response.ok) {
+        const text = await response.text();
+        console.error(`Save failed: ${response.status}`, text);
+        throw new Error(`Failed to save template: ${response.status}`);
+    }
+    
+    return await response.json();
 }
 
 export async function previewEmailTemplate(params: {
@@ -186,18 +145,37 @@ export async function previewEmailTemplate(params: {
     template: EmailTemplateModel;
     context?: Record<string, string>;
 }): Promise<EmailTemplateModel> {
-    await wait(200);
-
-    const config = EMAIL_TEMPLATE_CONFIGS[params.key];
-    const context = {
-        ...config.sampleContext,
-        ...(params.context ?? {}),
-    };
-
-    return {
-        subject: renderTemplateString(params.template.subject, context),
-        body: renderTemplateString(params.template.body, context),
-    };
+    const spaceId = window.location.pathname.split('/')[2];
+    
+    const response = await fetch(`${API_BASE_URL}/spaces/${spaceId}/settings/email-templates/preview`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+        body: JSON.stringify({
+            template: {
+                subject: params.template.subject,
+                body: params.template.body,
+            },
+            context: params.context || {},
+        }),
+    });
+    
+    if (!response.ok) {
+        const config = EMAIL_TEMPLATE_CONFIGS[params.key];
+        const context = {
+            ...config.sampleContext,
+            ...(params.context ?? {}),
+        };
+        
+        return {
+            subject: params.template.subject.replace(TOKEN_PATTERN, (_, varName) => context[varName] || `{{${varName}}}`),
+            body: params.template.body.replace(TOKEN_PATTERN, (_, varName) => context[varName] || `{{${varName}}}`),
+        };
+    }
+    
+    return await response.json();
 }
 
 export async function testSendEmailTemplate(params: {
@@ -205,11 +183,27 @@ export async function testSendEmailTemplate(params: {
     template: EmailTemplateModel;
     context?: Record<string, string>;
 }): Promise<{ recipient: string; messageId: string }> {
-    await previewEmailTemplate(params);
-    await wait(200);
-
-    return {
-        recipient: "test@example.com",
-        messageId: `stub-${Date.now()}`,
-    };
+    const spaceId = window.location.pathname.split('/')[2];
+    
+    const response = await fetch(`/spaces/${spaceId}/settings/email-templates/test-send`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            template: {
+                subject: params.template.subject,
+                body: params.template.body,
+            },
+            context: params.context || {},
+            to: "test@example.com",
+        }),
+    });
+    
+    if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.detail || `Failed to send test email: ${response.statusText}`);
+    }
+    
+    return await response.json();
 }


### PR DESCRIPTION
**Что было сделано?**

Добавлено сохранение шаблонов системных писем. При создании пользователя и смене пароля отправляются письма установленного шаблона.

**Зачем это было сделано?**

В соответствии с [задачей](https://github.com/moevm/rocket-administration-app/issues/166)

**Как это было протестировано?**

Вручную. Чтобы протестировать, нужно поднять smtp сервер локально:
`docker run -d -p 1025:1025 -p 8025:8025 mailhog/mailhog`

В настройках SMTP админ-панели:
Хост: localhost
Порт: 1025
TLS не включать

Остальные поля произвольные